### PR TITLE
#9: Preserve nightly reports on rerun

### DIFF
--- a/agents/nightly.yaml
+++ b/agents/nightly.yaml
@@ -9,7 +9,7 @@ prompt: prompts/nightly.md
 # See policies/nightly-policy.md for the full autonomy ladder (v1 → v4)
 # and policies/liveness-policy.md §22.5.8 for the anti_stall_report requirement.
 
-current_level: v1   # report-only at bootstrap. Anis raises this manually.
+current_level: v2   # Anis approved v2 on 2026-04-29: report + create improvement issues only.
 
 responsibilities:
   - analyze ai-system files

--- a/scripts/nightly.py
+++ b/scripts/nightly.py
@@ -13,6 +13,7 @@ scripts/repo_health.py.
 
 from __future__ import annotations
 
+import argparse
 import json
 import subprocess
 import sys
@@ -110,20 +111,46 @@ def report_skeleton() -> str:
     return "\n".join(sections)
 
 
-def main() -> int:
-    if halted():
-        print("HALT file present; nightly aborted.", file=sys.stderr)
-        return 0
+def nightly_report_path(now: datetime | None = None) -> Path:
+    timestamp = now or datetime.now(timezone.utc)
+    return REPO_ROOT / "reports" / "nightly" / f"{timestamp.date().isoformat()}.md"
 
-    out_dir = REPO_ROOT / "reports" / "nightly"
-    out_dir.mkdir(parents=True, exist_ok=True)
-    out = out_dir / f"{datetime.now(timezone.utc).date().isoformat()}.md"
+
+def write_report_skeleton(*, force: bool = False) -> Path:
+    out = nightly_report_path()
+    out.parent.mkdir(parents=True, exist_ok=True)
+
+    if out.exists() and out.read_text(encoding="utf-8").strip() and not force:
+        print(f"Preserved existing report: {out.relative_to(REPO_ROOT)}")
+        print("Use --force to regenerate the nightly skeleton.")
+        return out
 
     out.write_text(report_skeleton(), encoding="utf-8")
     print(f"Wrote skeleton: {out.relative_to(REPO_ROOT)}")
     print(
         "Next: nightly agent (local model) fills in the sections per prompts/nightly.md."
     )
+    return out
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Generate the nightly report skeleton.")
+    parser.add_argument(
+        "--force",
+        action="store_true",
+        help="overwrite an existing non-empty report for today",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv or sys.argv[1:])
+
+    if halted():
+        print("HALT file present; nightly aborted.", file=sys.stderr)
+        return 0
+
+    write_report_skeleton(force=args.force)
     return 0
 
 

--- a/tests/test_nightly_preserve_report.py
+++ b/tests/test_nightly_preserve_report.py
@@ -1,0 +1,47 @@
+import importlib.util
+import tempfile
+import unittest
+from pathlib import Path
+
+
+MODULE_PATH = Path(__file__).resolve().parents[1] / "scripts" / "nightly.py"
+
+
+def load_nightly_module():
+    spec = importlib.util.spec_from_file_location("nightly_under_test", MODULE_PATH)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+class NightlyPreserveReportTest(unittest.TestCase):
+    def test_rerun_preserves_existing_non_empty_report_without_force(self):
+        nightly = load_nightly_module()
+        with tempfile.TemporaryDirectory() as tmp:
+            nightly.REPO_ROOT = Path(tmp)
+            report = nightly.nightly_report_path()
+            report.parent.mkdir(parents=True)
+            report.write_text("filled report\n", encoding="utf-8")
+
+            nightly.write_report_skeleton(force=False)
+
+            self.assertEqual(report.read_text(encoding="utf-8"), "filled report\n")
+
+    def test_force_overwrites_existing_report(self):
+        nightly = load_nightly_module()
+        nightly.quota_state = lambda: {"state": "green", "remaining_pct": 100}
+        nightly.repo_health = lambda: {"verdict": "green"}
+        with tempfile.TemporaryDirectory() as tmp:
+            nightly.REPO_ROOT = Path(tmp)
+            report = nightly.nightly_report_path()
+            report.parent.mkdir(parents=True)
+            report.write_text("filled report\n", encoding="utf-8")
+
+            nightly.write_report_skeleton(force=True)
+
+            self.assertIn("# Nightly Report", report.read_text(encoding="utf-8"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
Fixes nightly reruns so an existing non-empty `reports/nightly/YYYY-MM-DD.md` is preserved by default instead of overwritten with a fresh skeleton.

Changes:
- Adds `--force` to intentionally regenerate the skeleton.
- Adds `nightly_report_path()` and `write_report_skeleton()` helpers.
- Adds unittest coverage for preserve-by-default and force-overwrite behavior.
- Persists Anis-approved nightly level promotion to `v2`.

## Linked issue
Closes #9

## Tests run
- `python3 -m unittest tests/test_nightly_preserve_report.py` → pass
- `python3 scripts/repo_health.py` → green
- `python3 evaluations/run_evals.py` → failed 1 existing executor eval (`04_add_react_component_from_signature`), unrelated to this nightly script change

## Risk
Low. Changes nightly skeleton generation behavior only. `--force` preserves the old overwrite behavior when explicitly requested.

## Cost flags
No paid API usage.

## Decisions needed from Anis
Merge when ready. Nightly is now v2 in this PR: reports + improvement issue creation only.
