### PR TITLE
meta: add conservative product autopilot

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ memory/        Long-lived context the system rehydrates from on session bootstra
 - New to the system? Read `README.md` (this file), then `policies/universal.md`, then `policies/liveness-policy.md`.
 - Building a feature? `workflows/feature-development.yaml`.
 - Starting a new product? Anis triggers `workflows/new-product.yaml`; the PM agent picks up.
+- Running a product without routine Anis/Vega intervention? Use `workflows/product-autopilot.yaml` and `scripts/product_autopilot.py` for one issue at a time.
 - Things look stuck? Run `scripts/repo_health.py` and check the latest `reports/nightly/`.
 
 ## Source plan

--- a/prompts/po.md
+++ b/prompts/po.md
@@ -60,6 +60,20 @@ You may merge a PR only if every gate below is true:
 
 If any gate fails, do not merge. Comment with the failed gate and next action.
 
+
+## Product autopilot mode
+
+When Vega or Anis asks for product autopilot, run only one issue at a time. Use:
+
+```bash
+python3 scripts/product_autopilot.py <product-name> --dry-run
+python3 scripts/product_autopilot.py <product-name> --claim
+```
+
+The script selects the next unblocked issue, skips Anis/cost/blocked labels, emits the exact PO-worker prompt, and can claim the issue. After that, execute the worker prompt through the normal issue → branch → PR → tests → CI → PO-gate → merge flow.
+
+Do not run a second issue until the first issue has merged or returned BLOCKED.
+
 ## Backlog ownership
 
 For each assigned product:

--- a/scripts/product_autopilot.py
+++ b/scripts/product_autopilot.py
@@ -1,0 +1,228 @@
+#!/usr/bin/env python3
+"""
+product_autopilot.py — conservative one-issue product autopilot coordinator.
+
+This script does not bypass the studio workflow. It selects one unblocked issue for
+an assigned product, builds the exact PO-worker task prompt, and optionally claims
+the issue with an autopilot comment.
+
+It is intentionally one issue at a time. The worker still uses normal GitHub flow:
+issue -> branch -> PR -> local tests -> CI -> PO gate comment -> PO-token merge.
+
+Usage:
+  python3 scripts/product_autopilot.py pregnancy-food-checker --dry-run
+  python3 scripts/product_autopilot.py pregnancy-food-checker --issue 37 --dry-run
+  python3 scripts/product_autopilot.py pregnancy-food-checker --claim
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from po_github import PoConfigError, github_get, halted, load_env_file, load_product, product_secret_path, validate
+
+
+BLOCKING_LABELS = {
+    "decision:anis",
+    "cost:approval-required",
+    "blocked",
+    "status:blocked",
+    "stuck",
+    "question",
+    "wontfix",
+    "invalid",
+    "duplicate",
+}
+
+PREFERRED_LABEL_ORDER = ["priority:P1", "priority:P2", "priority:P3"]
+
+
+@dataclass(frozen=True)
+class Issue:
+    number: int
+    title: str
+    body: str
+    labels: tuple[str, ...]
+    html_url: str
+    created_at: str
+    updated_at: str
+
+    @property
+    def is_blocked(self) -> bool:
+        return bool(set(self.labels) & BLOCKING_LABELS)
+
+    @property
+    def priority_rank(self) -> int:
+        for idx, label in enumerate(PREFERRED_LABEL_ORDER):
+            if label in self.labels:
+                return idx
+        return len(PREFERRED_LABEL_ORDER)
+
+
+def github_post(token: str, path: str, payload: dict[str, Any]) -> Any:
+    url = f"https://api.github.com{path}"
+    req = urllib.request.Request(url, data=json.dumps(payload).encode("utf-8"), method="POST")
+    req.add_header("Authorization", f"Bearer {token}")
+    req.add_header("Accept", "application/vnd.github+json")
+    req.add_header("Content-Type", "application/json")
+    req.add_header("X-GitHub-Api-Version", "2022-11-28")
+    try:
+        with urllib.request.urlopen(req, timeout=20) as response:
+            return json.loads(response.read().decode("utf-8"))
+    except urllib.error.HTTPError as exc:
+        detail = exc.read().decode("utf-8", errors="replace")
+        raise PoConfigError(f"GitHub API {exc.code} for {url}: {detail}") from exc
+
+
+def load_po_token(product: dict[str, Any]) -> str:
+    secret_path = product_secret_path(product)
+    env = load_env_file(secret_path)
+    token = env.get("GITHUB_TOKEN")
+    if not token:
+        raise PoConfigError(f"GITHUB_TOKEN missing from {secret_path}")
+    return token
+
+
+def parse_issue(raw: dict[str, Any]) -> Issue:
+    return Issue(
+        number=int(raw["number"]),
+        title=str(raw.get("title", "")),
+        body=str(raw.get("body") or ""),
+        labels=tuple(label.get("name", "") for label in raw.get("labels", [])),
+        html_url=str(raw.get("html_url", "")),
+        created_at=str(raw.get("created_at", "")),
+        updated_at=str(raw.get("updated_at", "")),
+    )
+
+
+def list_open_issues(token: str, repo: str) -> list[Issue]:
+    query = urllib.parse.urlencode({"state": "open", "per_page": 100})
+    raw_issues = github_get(token, f"/repos/{repo}/issues?{query}")
+    if not isinstance(raw_issues, list):
+        raise PoConfigError("unexpected issues response")
+    issues = [parse_issue(item) for item in raw_issues if "pull_request" not in item]
+    return sorted(issues, key=lambda issue: (issue.priority_rank, issue.created_at, issue.number))
+
+
+def choose_issue(issues: list[Issue], issue_number: int | None = None) -> Issue | None:
+    ordered = sorted(issues, key=lambda issue: (issue.priority_rank, issue.created_at, issue.number))
+    if issue_number is not None:
+        for issue in ordered:
+            if issue.number == issue_number:
+                return None if issue.is_blocked else issue
+        return None
+    for issue in ordered:
+        if not issue.is_blocked:
+            return issue
+    return None
+
+
+def build_worker_prompt(product_name: str, product: dict[str, Any], issue: Issue) -> str:
+    repo = product["repo"]
+    return f"""You are acting as the repo-scoped Product Owner for {repo}, assigned to product {product_name}. Run this issue end-to-end with minimal parent intervention.
+
+Issue: {issue.html_url}
+Title: {issue.title}
+Labels: {', '.join(issue.labels) or '(none)'}
+
+Hard requirements:
+- Do not print or expose secrets.
+- Validate PO credential boundary before merge using: python3 /tmp/ai-system-po/scripts/po_github.py validate {product_name}
+- Use normal GitHub flow: inspect issue, create branch, commit, PR, local tests, CI, PO gate comment, merge with PO token only if gates pass.
+- Use the PO token only by sourcing ~/.ai-system/secrets/{product.get('po_agent')}.env locally; never echo it.
+- Keep change small and one-concern.
+- Stop and return BLOCKED if the issue requires cost, API tokens/secrets, Render/provider setup, privacy/legal/product direction, public release, branch protection, or any exception to PO merge gates.
+- Add or update regression tests for the behavior.
+- Run the relevant focused test, npm test, and npm run build locally before PR when this is the Next.js product.
+- Wait for GitHub CI to pass before PO merge.
+- After merge, verify PR merged by the PO token user and linked issue closed.
+
+PO merge gates:
+- assigned repo: pass/fail
+- reviewer: pass/fail
+- CI/checks: pass/fail
+- cost/privacy/release gates: pass/fail
+- unresolved blockers: pass/fail
+- one-concern diff: pass/fail
+
+Final response back to parent must include: issue URL, PR URL, merge status, tests run, risk, cost flags, decisions needed, heartbeat."""
+
+
+def claim_issue(token: str, repo: str, issue: Issue) -> str:
+    body = (
+        "Autopilot picked this issue for one-issue PO execution. "
+        "It will stop and report BLOCKED if cost, secrets, provider setup, privacy/legal, "
+        "product direction, release, branch protection, or merge-gate exceptions are needed."
+    )
+    response = github_post(token, f"/repos/{repo}/issues/{issue.number}/comments", {"body": body})
+    return str(response.get("html_url", ""))
+
+
+def run(product_name: str, issue_number: int | None, claim: bool) -> dict[str, Any]:
+    validation = validate(product_name)
+    if validation["verdict"] != "pass":
+        return {"verdict": "blocked", "reason": "po credential validation failed", "validation": validation}
+
+    product = load_product(product_name)
+    repo = str(product["repo"])
+    token = load_po_token(product)
+    issues = list_open_issues(token, repo)
+    issue = choose_issue(issues, issue_number)
+    if issue is None:
+        return {
+            "verdict": "blocked",
+            "reason": "no unblocked matching issue",
+            "open_issues": [
+                {"number": item.number, "title": item.title, "labels": list(item.labels), "blocked": item.is_blocked}
+                for item in issues
+            ],
+        }
+
+    claim_url = claim_issue(token, repo, issue) if claim else None
+    return {
+        "verdict": "ready",
+        "product": product_name,
+        "repo": repo,
+        "issue": {
+            "number": issue.number,
+            "title": issue.title,
+            "url": issue.html_url,
+            "labels": list(issue.labels),
+        },
+        "claim_comment": claim_url,
+        "worker_prompt": build_worker_prompt(product_name, product, issue),
+    }
+
+
+def main() -> int:
+    if halted():
+        print(json.dumps({"halted": True, "reason": str(Path("~/.ai-system/HALT").expanduser())}, indent=2))
+        return 0
+
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("product", help="product config name, e.g. pregnancy-food-checker")
+    parser.add_argument("--issue", type=int, help="specific issue number to run instead of selecting next unblocked issue")
+    parser.add_argument("--claim", action="store_true", help="post an autopilot claim comment to the selected issue")
+    parser.add_argument("--dry-run", action="store_true", help="do not claim the issue; print selected issue and worker prompt")
+    args = parser.parse_args()
+
+    try:
+        result = run(args.product, args.issue, claim=args.claim and not args.dry_run)
+    except PoConfigError as exc:
+        print(json.dumps({"verdict": "blocked", "error": str(exc)}, indent=2))
+        return 1
+
+    print(json.dumps(result, indent=2))
+    return 0 if result.get("verdict") == "ready" else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_product_autopilot.py
+++ b/tests/test_product_autopilot.py
@@ -1,0 +1,72 @@
+import importlib.util
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "scripts"))
+spec = importlib.util.spec_from_file_location("product_autopilot", ROOT / "scripts" / "product_autopilot.py")
+product_autopilot = importlib.util.module_from_spec(spec)
+sys.modules["product_autopilot"] = product_autopilot
+assert spec.loader is not None
+spec.loader.exec_module(product_autopilot)
+
+Issue = product_autopilot.Issue
+choose_issue = product_autopilot.choose_issue
+build_worker_prompt = product_autopilot.build_worker_prompt
+
+
+def issue(number, title, labels=(), created="2026-01-01T00:00:00Z"):
+    return Issue(
+        number=number,
+        title=title,
+        body="",
+        labels=tuple(labels),
+        html_url=f"https://github.com/chaibi-labs/pregnancy-food-checker/issues/{number}",
+        created_at=created,
+        updated_at=created,
+    )
+
+
+def test_choose_issue_skips_anis_decision_and_cost_blockers():
+    issues = [
+        issue(1, "Needs token", ["priority:P1", "decision:anis"]),
+        issue(2, "Paid lookup", ["priority:P1", "cost:approval-required"]),
+        issue(3, "Safe UI polish", ["priority:P2"]),
+    ]
+
+    selected = choose_issue(issues)
+
+    assert selected is not None
+    assert selected.number == 3
+
+
+def test_choose_issue_honors_priority_then_age():
+    issues = [
+        issue(1, "Older P3", ["priority:P3"], "2026-01-01T00:00:00Z"),
+        issue(2, "Newer P1", ["priority:P1"], "2026-02-01T00:00:00Z"),
+        issue(3, "Older P2", ["priority:P2"], "2026-01-15T00:00:00Z"),
+    ]
+
+    selected = choose_issue(issues)
+
+    assert selected is not None
+    assert selected.number == 2
+
+
+def test_specific_blocked_issue_is_not_selected():
+    issues = [issue(10, "Needs Anis", ["decision:anis"])]
+
+    assert choose_issue(issues, issue_number=10) is None
+
+
+def test_worker_prompt_contains_hard_stops_and_po_merge_gates():
+    product = {"repo": "chaibi-labs/pregnancy-food-checker", "po_agent": "po-pregnancy-food-checker"}
+    prompt = build_worker_prompt("pregnancy-food-checker", product, issue(9, "Do thing", ["priority:P2"]))
+
+    assert "python3 /tmp/ai-system-po/scripts/po_github.py validate pregnancy-food-checker" in prompt
+    assert "Stop and return BLOCKED" in prompt
+    assert "cost" in prompt
+    assert "API tokens/secrets" in prompt
+    assert "PO merge gates" in prompt
+    assert "CI/checks: pass/fail" in prompt
+    assert "sourcing ~/.ai-system/secrets/po-pregnancy-food-checker.env" in prompt

--- a/workflows/product-autopilot.yaml
+++ b/workflows/product-autopilot.yaml
@@ -1,0 +1,49 @@
+name: product-autopilot
+description: Conservative one-issue-at-a-time autopilot for an assigned product PO.
+trigger: "Vega or Anis requests autopilot for a product"
+
+principles:
+  - one issue per run
+  - no cost, secrets, provider setup, release, branch-protection, or product-direction decisions without Anis
+  - use normal GitHub issue/branch/PR/CI flow
+  - merge only through the assigned Product Owner token after PO gates pass
+  - stop loudly with BLOCKED instead of guessing
+
+steps:
+  - agent: po
+    task: validate repo-scoped PO credential boundary with scripts/po_github.py
+    output: validation JSON with verdict pass
+
+  - agent: po
+    task: select one unblocked issue with scripts/product_autopilot.py; prefer priority labels then age
+    output: selected issue and worker prompt
+
+  - agent: po
+    task: claim the issue with an autopilot comment
+    output: claim comment URL
+
+  - agent: po-worker
+    task: execute the worker prompt for the selected issue
+    output: PR URL, local test output, CI state, PO gate checklist
+
+  - agent: po
+    task: merge with PO token if all PO merge gates pass; otherwise comment with failed gate and return BLOCKED
+    output: merged PR or BLOCKED gate
+
+hard_stops:
+  - cost or paid quota
+  - API tokens, OAuth credentials, secrets, Render/provider setup, domains, accounts
+  - privacy/legal choice
+  - product direction, brand, pricing, or launch choice
+  - public release or new exposure
+  - branch protection or merge-authority changes
+  - failing or missing CI
+  - unresolved blocker comments
+
+outputs:
+  - selected issue URL
+  - PR URL or BLOCKED reason
+  - tests run
+  - PO gate checklist
+  - merge status
+  - next unblocked issue if any


### PR DESCRIPTION
## Summary
- add conservative one-issue product autopilot workflow
- add `scripts/product_autopilot.py` to validate PO credentials, select one unblocked issue, optionally claim it, and emit the exact PO-worker prompt
- document autopilot mode in the PO prompt and README

## Linked issue
- none

## Tests run
- `python3 scripts/product_autopilot.py pregnancy-food-checker --dry-run` → selected next unblocked issue and emitted worker prompt
- `python3 scripts/repo_health.py` → green
- `python3 -m pytest tests/test_nightly_preserve_report.py tests/test_coder_execute_scope_guard.py tests/test_product_autopilot.py` → 11 passed

## Risk
medium — introduces an autopilot coordinator, but it is intentionally one issue at a time and stops on cost/secrets/provider/privacy/product/release/branch-protection gates.

## Cost flags
none

## Decisions needed from Anis
- Merge if this conservative autopilot boundary is acceptable.
