### PR TITLE
meta: support bounded autopilot issue loops

### DIFF
--- a/prompts/po.md
+++ b/prompts/po.md
@@ -63,16 +63,18 @@ If any gate fails, do not merge. Comment with the failed gate and next action.
 
 ## Product autopilot mode
 
-When Vega or Anis asks for product autopilot, run only one issue at a time. Use:
+When Vega or Anis asks for product autopilot, default to one issue at a time. Use an explicit bounded max for multi-issue loops:
 
 ```bash
 python3 scripts/product_autopilot.py <product-name> --dry-run
 python3 scripts/product_autopilot.py <product-name> --claim
+python3 scripts/product_autopilot.py <product-name> --max-issues 3 --dry-run
+python3 scripts/product_autopilot.py <product-name> --max-issues 3 --claim
 ```
 
-The script selects the next unblocked issue, skips Anis/cost/blocked labels, emits the exact PO-worker prompt, and can claim the issue. After that, execute the worker prompt through the normal issue → branch → PR → tests → CI → PO-gate → merge flow.
+The script selects unblocked issues, skips Anis/cost/blocked labels, emits exact PO-worker prompts, and can claim each issue. Execute worker prompts serially through the normal issue → branch → PR → tests → CI → PO-gate → merge flow.
 
-Do not run a second issue until the first issue has merged or returned BLOCKED.
+For multi-issue loops: no parallel workers, no batch merges, and stop immediately after the first issue returns BLOCKED or fails a PO merge gate.
 
 ## Backlog ownership
 

--- a/scripts/product_autopilot.py
+++ b/scripts/product_autopilot.py
@@ -1,18 +1,19 @@
 #!/usr/bin/env python3
 """
-product_autopilot.py — conservative one-issue product autopilot coordinator.
+product_autopilot.py — conservative product autopilot coordinator.
 
-This script does not bypass the studio workflow. It selects one unblocked issue for
-an assigned product, builds the exact PO-worker task prompt, and optionally claims
-the issue with an autopilot comment.
+This script does not bypass the studio workflow. It selects unblocked issues for
+an assigned product, builds exact PO-worker task prompts, and optionally claims
+each issue with an autopilot comment.
 
-It is intentionally one issue at a time. The worker still uses normal GitHub flow:
+It supports a bounded serial loop. Workers still use normal GitHub flow:
 issue -> branch -> PR -> local tests -> CI -> PO gate comment -> PO-token merge.
 
 Usage:
   python3 scripts/product_autopilot.py pregnancy-food-checker --dry-run
   python3 scripts/product_autopilot.py pregnancy-food-checker --issue 37 --dry-run
   python3 scripts/product_autopilot.py pregnancy-food-checker --claim
+  python3 scripts/product_autopilot.py pregnancy-food-checker --max-issues 3 --dry-run
 """
 
 from __future__ import annotations
@@ -112,6 +113,11 @@ def list_open_issues(token: str, repo: str) -> list[Issue]:
     return sorted(issues, key=lambda issue: (issue.priority_rank, issue.created_at, issue.number))
 
 
+def ordered_unblocked_issues(issues: list[Issue]) -> list[Issue]:
+    ordered = sorted(issues, key=lambda issue: (issue.priority_rank, issue.created_at, issue.number))
+    return [issue for issue in ordered if not issue.is_blocked]
+
+
 def choose_issue(issues: list[Issue], issue_number: int | None = None) -> Issue | None:
     ordered = sorted(issues, key=lambda issue: (issue.priority_rank, issue.created_at, issue.number))
     if issue_number is not None:
@@ -119,10 +125,17 @@ def choose_issue(issues: list[Issue], issue_number: int | None = None) -> Issue 
             if issue.number == issue_number:
                 return None if issue.is_blocked else issue
         return None
-    for issue in ordered:
-        if not issue.is_blocked:
-            return issue
-    return None
+    unblocked = ordered_unblocked_issues(issues)
+    return unblocked[0] if unblocked else None
+
+
+def choose_issues(issues: list[Issue], max_issues: int, issue_number: int | None = None) -> list[Issue]:
+    if max_issues < 1:
+        raise PoConfigError("max_issues must be at least 1")
+    if issue_number is not None:
+        selected = choose_issue(issues, issue_number)
+        return [selected] if selected else []
+    return ordered_unblocked_issues(issues)[:max_issues]
 
 
 def build_worker_prompt(product_name: str, product: dict[str, Any], issue: Issue) -> str:
@@ -156,9 +169,9 @@ PO merge gates:
 Final response back to parent must include: issue URL, PR URL, merge status, tests run, risk, cost flags, decisions needed, heartbeat."""
 
 
-def claim_issue(token: str, repo: str, issue: Issue) -> str:
+def claim_issue(token: str, repo: str, issue: Issue, run_position: int = 1, run_total: int = 1) -> str:
     body = (
-        "Autopilot picked this issue for one-issue PO execution. "
+        f"Autopilot picked this issue for PO execution ({run_position}/{run_total} in this bounded serial run). "
         "It will stop and report BLOCKED if cost, secrets, provider setup, privacy/legal, "
         "product direction, release, branch protection, or merge-gate exceptions are needed."
     )
@@ -166,7 +179,16 @@ def claim_issue(token: str, repo: str, issue: Issue) -> str:
     return str(response.get("html_url", ""))
 
 
-def run(product_name: str, issue_number: int | None, claim: bool) -> dict[str, Any]:
+def issue_json(issue: Issue) -> dict[str, Any]:
+    return {
+        "number": issue.number,
+        "title": issue.title,
+        "url": issue.html_url,
+        "labels": list(issue.labels),
+    }
+
+
+def run(product_name: str, issue_number: int | None, claim: bool, max_issues: int = 1) -> dict[str, Any]:
     validation = validate(product_name)
     if validation["verdict"] != "pass":
         return {"verdict": "blocked", "reason": "po credential validation failed", "validation": validation}
@@ -175,8 +197,8 @@ def run(product_name: str, issue_number: int | None, claim: bool) -> dict[str, A
     repo = str(product["repo"])
     token = load_po_token(product)
     issues = list_open_issues(token, repo)
-    issue = choose_issue(issues, issue_number)
-    if issue is None:
+    selected_issues = choose_issues(issues, max_issues=max_issues, issue_number=issue_number)
+    if not selected_issues:
         return {
             "verdict": "blocked",
             "reason": "no unblocked matching issue",
@@ -186,20 +208,34 @@ def run(product_name: str, issue_number: int | None, claim: bool) -> dict[str, A
             ],
         }
 
-    claim_url = claim_issue(token, repo, issue) if claim else None
-    return {
+    total = len(selected_issues)
+    runs = []
+    for index, issue in enumerate(selected_issues, start=1):
+        claim_url = claim_issue(token, repo, issue, run_position=index, run_total=total) if claim else None
+        runs.append({
+            "issue": issue_json(issue),
+            "claim_comment": claim_url,
+            "worker_prompt": build_worker_prompt(product_name, product, issue),
+            "run_position": index,
+            "run_total": total,
+        })
+
+    result = {
         "verdict": "ready",
         "product": product_name,
         "repo": repo,
-        "issue": {
-            "number": issue.number,
-            "title": issue.title,
-            "url": issue.html_url,
-            "labels": list(issue.labels),
-        },
-        "claim_comment": claim_url,
-        "worker_prompt": build_worker_prompt(product_name, product, issue),
+        "mode": "multi" if len(runs) > 1 else "single",
+        "max_issues": max_issues,
+        "runs": runs,
     }
+    # Backwards-compatible fields for callers that expect a one-issue response.
+    if len(runs) == 1:
+        result.update({
+            "issue": runs[0]["issue"],
+            "claim_comment": runs[0]["claim_comment"],
+            "worker_prompt": runs[0]["worker_prompt"],
+        })
+    return result
 
 
 def main() -> int:
@@ -210,12 +246,13 @@ def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("product", help="product config name, e.g. pregnancy-food-checker")
     parser.add_argument("--issue", type=int, help="specific issue number to run instead of selecting next unblocked issue")
-    parser.add_argument("--claim", action="store_true", help="post an autopilot claim comment to the selected issue")
-    parser.add_argument("--dry-run", action="store_true", help="do not claim the issue; print selected issue and worker prompt")
+    parser.add_argument("--claim", action="store_true", help="post an autopilot claim comment to selected issue(s)")
+    parser.add_argument("--dry-run", action="store_true", help="do not claim issues; print selected issue(s) and worker prompts")
+    parser.add_argument("--max-issues", type=int, default=1, help="maximum number of unblocked issues to select for a bounded serial run (default: 1)")
     args = parser.parse_args()
 
     try:
-        result = run(args.product, args.issue, claim=args.claim and not args.dry_run)
+        result = run(args.product, args.issue, claim=args.claim and not args.dry_run, max_issues=args.max_issues)
     except PoConfigError as exc:
         print(json.dumps({"verdict": "blocked", "error": str(exc)}, indent=2))
         return 1

--- a/tests/test_product_autopilot.py
+++ b/tests/test_product_autopilot.py
@@ -12,6 +12,7 @@ spec.loader.exec_module(product_autopilot)
 
 Issue = product_autopilot.Issue
 choose_issue = product_autopilot.choose_issue
+choose_issues = product_autopilot.choose_issues
 build_worker_prompt = product_autopilot.build_worker_prompt
 
 
@@ -70,3 +71,27 @@ def test_worker_prompt_contains_hard_stops_and_po_merge_gates():
     assert "PO merge gates" in prompt
     assert "CI/checks: pass/fail" in prompt
     assert "sourcing ~/.ai-system/secrets/po-pregnancy-food-checker.env" in prompt
+
+
+def test_choose_issues_returns_bounded_serial_batch():
+    issues = [
+        issue(1, "Needs token", ["priority:P1", "decision:anis"]),
+        issue(2, "First safe", ["priority:P1"], "2026-01-02T00:00:00Z"),
+        issue(3, "Second safe", ["priority:P2"], "2026-01-01T00:00:00Z"),
+        issue(4, "Third safe", ["priority:P3"], "2026-01-01T00:00:00Z"),
+    ]
+
+    selected = choose_issues(issues, max_issues=2)
+
+    assert [item.number for item in selected] == [2, 3]
+
+
+def test_choose_issues_with_specific_issue_ignores_batch_size():
+    issues = [
+        issue(2, "First safe", ["priority:P1"]),
+        issue(3, "Second safe", ["priority:P2"]),
+    ]
+
+    selected = choose_issues(issues, max_issues=5, issue_number=3)
+
+    assert [item.number for item in selected] == [3]

--- a/workflows/product-autopilot.yaml
+++ b/workflows/product-autopilot.yaml
@@ -1,9 +1,10 @@
 name: product-autopilot
-description: Conservative one-issue-at-a-time autopilot for an assigned product PO.
+description: Conservative bounded serial autopilot for an assigned product PO.
 trigger: "Vega or Anis requests autopilot for a product"
 
 principles:
-  - one issue per run
+  - bounded serial run; default one issue, explicit max required for more
+  - no parallel workers and no second issue starts after a BLOCKED/failed issue
   - no cost, secrets, provider setup, release, branch-protection, or product-direction decisions without Anis
   - use normal GitHub issue/branch/PR/CI flow
   - merge only through the assigned Product Owner token after PO gates pass
@@ -15,20 +16,20 @@ steps:
     output: validation JSON with verdict pass
 
   - agent: po
-    task: select one unblocked issue with scripts/product_autopilot.py; prefer priority labels then age
-    output: selected issue and worker prompt
+    task: select up to max_issues unblocked issues with scripts/product_autopilot.py; prefer priority labels then age
+    output: selected issue(s) and worker prompt(s)
 
   - agent: po
-    task: claim the issue with an autopilot comment
-    output: claim comment URL
+    task: claim selected issue(s) with autopilot comments
+    output: claim comment URL(s)
 
   - agent: po-worker
-    task: execute the worker prompt for the selected issue
+    task: execute worker prompts serially; stop after first BLOCKED or failed worker
     output: PR URL, local test output, CI state, PO gate checklist
 
   - agent: po
     task: merge with PO token if all PO merge gates pass; otherwise comment with failed gate and return BLOCKED
-    output: merged PR or BLOCKED gate
+    output: merged PR(s) or first BLOCKED gate
 
 hard_stops:
   - cost or paid quota
@@ -41,8 +42,8 @@ hard_stops:
   - unresolved blocker comments
 
 outputs:
-  - selected issue URL
-  - PR URL or BLOCKED reason
+  - selected issue URL(s)
+  - PR URL(s) or first BLOCKED reason
   - tests run
   - PO gate checklist
   - merge status


### PR DESCRIPTION
## Summary
- extend product autopilot from one issue to an explicit bounded serial loop via `--max-issues`
- keep default behavior at one issue
- document no parallel workers, no batch merges, and stop-after-first-BLOCKED/failure behavior
- add tests for bounded issue selection

## Linked issue
- none

## Tests run
- `python3 scripts/product_autopilot.py pregnancy-food-checker --max-issues 3 --dry-run` → ready; currently selected the only unblocked issue (#29)
- `python3 scripts/repo_health.py` → green
- `python3 -m pytest tests/test_nightly_preserve_report.py tests/test_coder_execute_scope_guard.py tests/test_product_autopilot.py` → 13 passed

## Risk
medium — enables multi-issue coordination, but serial only and bounded by explicit `--max-issues`; default remains one issue.

## Cost flags
none

## Decisions needed from Anis
- Merge if this bounded loop behavior is acceptable.
