### PR TITLE
meta: repair internal autopilot failures within budget

### DIFF
--- a/prompts/po.md
+++ b/prompts/po.md
@@ -74,7 +74,7 @@ python3 scripts/product_autopilot.py <product-name> --max-issues 3 --claim
 
 The script selects unblocked issues, skips Anis/cost/blocked labels, emits exact PO-worker prompts, and can claim each issue. Execute worker prompts serially through the normal issue → branch → PR → tests → CI → PO-gate → merge flow.
 
-For multi-issue loops: no parallel workers, no batch merges, and stop immediately after the first issue returns BLOCKED or fails a PO merge gate.
+For multi-issue loops: no parallel workers and no batch merges. Do not move to the next issue until the current issue is merged or externally BLOCKED. Internal failures are not immediate stop conditions: tests, lint, build, CI, merge conflicts, and reviewer blockers should be repaired within budget (default max 3 focused repair attempts). Stop and escalate only when an external gate appears or the repair budget is exhausted.
 
 ## Backlog ownership
 

--- a/scripts/product_autopilot.py
+++ b/scripts/product_autopilot.py
@@ -152,10 +152,12 @@ Hard requirements:
 - Use normal GitHub flow: inspect issue, create branch, commit, PR, local tests, CI, PO gate comment, merge with PO token only if gates pass.
 - Use the PO token only by sourcing ~/.ai-system/secrets/{product.get('po_agent')}.env locally; never echo it.
 - Keep change small and one-concern.
-- Stop and return BLOCKED if the issue requires cost, API tokens/secrets, Render/provider setup, privacy/legal/product direction, public release, branch protection, or any exception to PO merge gates.
+- Stop and return BLOCKED only for external gates: cost, API tokens/secrets, Render/provider setup, privacy/legal/product direction, public release, branch protection, or any exception to PO merge gates.
+- For internal fixable failures (local test/lint/build failure, CI red, merge conflict, or review blocker), repair within budget before giving up.
+- Repair budget: up to 3 focused repair attempts per issue, then mark STUCK/BLOCKED with exact failure evidence.
 - Add or update regression tests for the behavior.
 - Run the relevant focused test, npm test, and npm run build locally before PR when this is the Next.js product.
-- Wait for GitHub CI to pass before PO merge.
+- Wait for GitHub CI to pass before PO merge. If CI fails, inspect logs, repair, push, and re-wait within budget.
 - After merge, verify PR merged by the PO token user and linked issue closed.
 
 PO merge gates:
@@ -166,7 +168,7 @@ PO merge gates:
 - unresolved blockers: pass/fail
 - one-concern diff: pass/fail
 
-Final response back to parent must include: issue URL, PR URL, merge status, tests run, risk, cost flags, decisions needed, heartbeat."""
+Final response back to parent must include: issue URL, PR URL, merge status, repair attempts used, tests run, risk, cost flags, decisions needed, heartbeat."""
 
 
 def claim_issue(token: str, repo: str, issue: Issue, run_position: int = 1, run_total: int = 1) -> str:

--- a/tests/test_product_autopilot.py
+++ b/tests/test_product_autopilot.py
@@ -95,3 +95,14 @@ def test_choose_issues_with_specific_issue_ignores_batch_size():
     selected = choose_issues(issues, max_issues=5, issue_number=3)
 
     assert [item.number for item in selected] == [3]
+
+
+def test_worker_prompt_repairs_internal_failures_before_blocking():
+    product = {"repo": "chaibi-labs/pregnancy-food-checker", "po_agent": "po-pregnancy-food-checker"}
+    prompt = build_worker_prompt("pregnancy-food-checker", product, issue(11, "Fix thing", ["priority:P2"]))
+
+    assert "Stop and return BLOCKED only for external gates" in prompt
+    assert "internal fixable failures" in prompt
+    assert "up to 3 focused repair attempts" in prompt
+    assert "If CI fails, inspect logs, repair, push" in prompt
+    assert "repair attempts used" in prompt

--- a/workflows/product-autopilot.yaml
+++ b/workflows/product-autopilot.yaml
@@ -4,11 +4,12 @@ trigger: "Vega or Anis requests autopilot for a product"
 
 principles:
   - bounded serial run; default one issue, explicit max required for more
-  - no parallel workers and no second issue starts after a BLOCKED/failed issue
+  - no parallel workers and no second issue starts until the current issue is merged or externally BLOCKED
+  - internal failures trigger bounded repair loops before escalation
   - no cost, secrets, provider setup, release, branch-protection, or product-direction decisions without Anis
   - use normal GitHub issue/branch/PR/CI flow
   - merge only through the assigned Product Owner token after PO gates pass
-  - stop loudly with BLOCKED instead of guessing
+  - stop loudly with BLOCKED instead of guessing when an external gate or repair budget is hit
 
 steps:
   - agent: po
@@ -24,7 +25,7 @@ steps:
     output: claim comment URL(s)
 
   - agent: po-worker
-    task: execute worker prompts serially; stop after first BLOCKED or failed worker
+    task: execute worker prompts serially; repair internal failures within budget; stop after first external BLOCKED or budget-exceeded STUCK
     output: PR URL, local test output, CI state, PO gate checklist
 
   - agent: po
@@ -38,12 +39,12 @@ hard_stops:
   - product direction, brand, pricing, or launch choice
   - public release or new exposure
   - branch protection or merge-authority changes
-  - failing or missing CI
-  - unresolved blocker comments
+  - failing or missing CI after repair budget is exhausted
+  - unresolved blocker comments after repair budget is exhausted
 
 outputs:
   - selected issue URL(s)
-  - PR URL(s) or first BLOCKED reason
+  - PR URL(s), repair attempts used, or first BLOCKED/STUCK reason
   - tests run
   - PO gate checklist
   - merge status


### PR DESCRIPTION
## Summary
- update autopilot semantics so internal failures trigger bounded repair loops instead of immediate stop
- keep external gates as hard stops: cost, secrets, provider setup, privacy/legal/product/release, branch protection
- document max 3 focused repair attempts per issue before STUCK/BLOCKED escalation
- require worker output to include repair attempts used

## Linked issue
- none

## Tests run
- `python3 scripts/product_autopilot.py pregnancy-food-checker --max-issues 3 --dry-run` → ready; worker prompt includes repair semantics
- `python3 scripts/repo_health.py` → green
- `python3 -m pytest tests/test_nightly_preserve_report.py tests/test_coder_execute_scope_guard.py tests/test_product_autopilot.py` → 14 passed

## Risk
medium — changes autopilot failure behavior, but repair is bounded and external gates still stop.

## Cost flags
none

## Decisions needed from Anis
- Merge if this repair-loop behavior matches intent.
