### PR TITLE
meta: promote nightly to v3

### DIFF
--- a/agents/nightly.yaml
+++ b/agents/nightly.yaml
@@ -9,7 +9,7 @@ prompt: prompts/nightly.md
 # See policies/nightly-policy.md for the full autonomy ladder (v1 → v4)
 # and policies/liveness-policy.md §22.5.8 for the anti_stall_report requirement.
 
-current_level: v2   # Anis approved v2 on 2026-04-29: report + create improvement issues only.
+current_level: v3   # Anis approved v3 on 2026-04-30: report + create issues + open ai-system PRs only.
 
 responsibilities:
   - analyze ai-system files


### PR DESCRIPTION
## Summary
- Promote nightly from v2 to v3 after Anis approval.
- v3 allows nightly to create reports, create improvement issues, and open PRs in `ai-system` only.
- No merge authority is added.

## Tests run
- Config-only change; no runtime tests run.

## Risk
Medium: increases nightly autonomy to open ai-system PRs, but it still cannot merge and still obeys cost/security/release hard stops.

## Cost flags
None.

## Decisions needed
- Anis merge required to make v3 active on `main`.
